### PR TITLE
Relax version bounds (unbreak package on `nixpkgs`)

### DIFF
--- a/migrant-core/migrant-core.cabal
+++ b/migrant-core/migrant-core.cabal
@@ -39,7 +39,7 @@ test-suite migrant-core-test
                , migrant-core
                , HUnit >=1.6.1.0 && <1.7
                , QuickCheck >=2.14.2 && <2.15
-               , tasty >=1.4 && <1.5
+               , tasty >=1.4 && <1.6
                , tasty-hunit >=0.10.0.2 && <0.11
-               , tasty-quickcheck >=0.10.1.1 && <0.11
+               , tasty-quickcheck >=0.10.1.1 && <0.12
                , text >=1.2 && <3

--- a/migrant-hdbc/migrant-hdbc.cabal
+++ b/migrant-hdbc/migrant-hdbc.cabal
@@ -41,7 +41,7 @@ test-suite migrant-hdbc-test
                , HDBC-sqlite3 >=2.3.3.1 && <2.4
                , process >=1.5 && <1.7
                , random >=1.2.0 && <1.3
-               , tasty >=1.4 && <1.5
+               , tasty >=1.4 && <1.6
                , tasty-hunit >=0.10.0.2 && <0.11
-               , tasty-quickcheck >=0.10.1.1 && <0.11
+               , tasty-quickcheck >=0.10.1.1 && <0.12
                , text >=1.2 && <3

--- a/migrant-postgresql-simple/migrant-postgresql-simple.cabal
+++ b/migrant-postgresql-simple/migrant-postgresql-simple.cabal
@@ -21,7 +21,7 @@ library
   -- other-extensions:
   build-depends: base >=4.12.0.0 && <5
                , migrant-core
-               , postgresql-simple >=0.6.3 && <0.7
+               , postgresql-simple >=0.6.3 && <0.8
                , text >=1.2 && <3
   hs-source-dirs: src
   default-language: Haskell2010
@@ -37,10 +37,10 @@ test-suite migrant-postgresql-simple-test
                , migrant-postgresql-simple
                , HUnit >=1.6.1.0 && <1.7
                , QuickCheck >=2.14.2 && <2.15
-               , postgresql-simple >=0.6.3 && <0.7
+               , postgresql-simple >=0.6.3 && <0.8
                , process >=1.5 && <1.7
                , random >=1.2.0 && <1.3
-               , tasty >=1.4 && <1.5
+               , tasty >=1.4 && <1.6
                , tasty-hunit >=0.10.0.2 && <0.11
-               , tasty-quickcheck >=0.10.1.1 && <0.11
+               , tasty-quickcheck >=0.10.1.1 && <0.12
                , text >=1.2 && <3

--- a/migrant-sqlite-simple/migrant-sqlite-simple.cabal
+++ b/migrant-sqlite-simple/migrant-sqlite-simple.cabal
@@ -38,7 +38,7 @@ test-suite migrant-sqlite-simple-test
                , HUnit >=1.6.1.0 && <1.7
                , QuickCheck >=2.14.2 && <2.15
                , sqlite-simple >=0.4.18.0 && <0.5
-               , tasty >=1.4 && <1.5
+               , tasty >=1.4 && <1.6
                , tasty-hunit >=0.10.0.2 && <0.11
-               , tasty-quickcheck >=0.10.1.1 && <0.11
+               , tasty-quickcheck >=0.10.1.1 && <0.12
                , text >=1.2 && <3


### PR DESCRIPTION
This PR relaxes some version upper bounds so that `migrant` family of packages build successfully on current `nixpkgs`-haskell package set.